### PR TITLE
Add filter and sort for blog dashboard

### DIFF
--- a/src/components/CategoryFilter/index.js
+++ b/src/components/CategoryFilter/index.js
@@ -1,0 +1,44 @@
+import {
+  Button,
+  Checkbox,
+  CheckboxGroup,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverArrow,
+  PopoverCloseButton,
+  PopoverHeader,
+  PopoverBody,
+  useColorModeValue,
+  Stack,
+} from "@chakra-ui/react";
+
+export default function CategoryFilter({ categories, selectedCategories, onChange }) {
+  const popoverBg = useColorModeValue("gray.50", "gray.700");
+  return (
+    <Popover closeOnBlur>
+      <PopoverTrigger>
+        <Button colorScheme="teal">Filter Categories</Button>
+      </PopoverTrigger>
+      <PopoverContent bg={popoverBg} boxShadow="md">
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader fontWeight="semibold">Categories</PopoverHeader>
+        <PopoverBody>
+          <CheckboxGroup value={selectedCategories} onChange={onChange}>
+            <Stack>
+              {categories.map((cat) => (
+                <Checkbox key={cat} value={cat}>
+                  {cat}
+                </Checkbox>
+              ))}
+            </Stack>
+          </CheckboxGroup>
+          <Button mt={4} size="sm" variant="outline" onClick={() => onChange([])}>
+            Clear
+          </Button>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/pages/Blog/BlogDashboard.js
+++ b/src/pages/Blog/BlogDashboard.js
@@ -1,23 +1,35 @@
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { usePostContext } from "../../features/posts/PostContext";
 import { fetchPosts } from "../../features/posts/PostServices";
 import {
+  Box,
   Container,
   Divider,
   Fade,
+  Flex,
   Grid,
   GridItem,
   Heading,
+  Select,
   Spinner,
   Stack,
+  Text,
+  useColorModeValue,
 } from "@chakra-ui/react";
 import { Helmet } from "react-helmet";
 import Thumbnail from "../../components/Thumbnail";
 import { useNavigate } from "react-router-dom";
+import CategoryFilter from "../../components/CategoryFilter";
+import { colors } from "../../theme/styles";
 
 export default function BlogDashboard() {
   const { post, dispatch: postDispatch } = usePostContext();
   const navigate = useNavigate();
+
+  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [sortOrder, setSortOrder] = useState("newest");
+  const [showControls, setShowControls] = useState(true);
+  const [lastScrollY, setLastScrollY] = useState(0);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -30,6 +42,50 @@ export default function BlogDashboard() {
     fetchData();
   }, [postDispatch]);
 
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+      if (currentScrollY > lastScrollY && currentScrollY > 100) {
+        setShowControls(false);
+      } else {
+        setShowControls(true);
+      }
+      setLastScrollY(currentScrollY);
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [lastScrollY]);
+
+  const categories = useMemo(() => {
+    const allCats = post.posts.flatMap((p) =>
+      Array.isArray(p.categories) ? p.categories : [p.categories]
+    );
+    return Array.from(new Set(allCats));
+  }, [post.posts]);
+
+  const sortedPosts = useMemo(() => {
+    const postsCopy = [...post.posts];
+    return postsCopy.sort((a, b) => {
+      if (sortOrder === "newest") {
+        return new Date(b.timestamp) - new Date(a.timestamp);
+      }
+      if (sortOrder === "oldest") {
+        return new Date(a.timestamp) - new Date(b.timestamp);
+      }
+      return (b.viewCount ?? 0) - (a.viewCount ?? 0);
+    });
+  }, [post.posts, sortOrder]);
+
+  const filteredPosts = useMemo(() => {
+    if (selectedCategories.length === 0) return sortedPosts;
+    return sortedPosts.filter((p) => {
+      const tags = Array.isArray(p.categories) ? p.categories : [p.categories];
+      return selectedCategories.some((cat) => tags.includes(cat));
+    });
+  }, [sortedPosts, selectedCategories]);
+
+  const controlBg = useColorModeValue(colors.lightest, "gray.900");
+
   return (
     <>
       <Helmet>
@@ -40,11 +96,41 @@ export default function BlogDashboard() {
         />
       </Helmet>
       <Fade in transition={{enter: { duration: 0.6 }}}>
+        <Box
+          position="sticky"
+          top={0}
+          zIndex={10}
+          bg={controlBg}
+          boxShadow="md"
+          transform={showControls ? "translateY(0)" : "translateY(-100%)"}
+          transition="transform 0.3s"
+        >
+          <Text color="gray.600" fontSize="sm" align={"center"} p={4}>
+            Showing {filteredPosts.length} post
+            {filteredPosts.length !== 1 ? "s" : ""}
+            {selectedCategories.length ? " matching selected categories" : ""}
+          </Text>
+          <Flex p={4} gap={4} justify="center" flexWrap="wrap">
+            <CategoryFilter
+              categories={categories}
+              selectedCategories={selectedCategories}
+              onChange={setSelectedCategories}
+            />
+            <Select
+              w="200px"
+              bg={useColorModeValue("gray.100", "gray.700")}
+              value={sortOrder}
+              onChange={(e) => setSortOrder(e.target.value)}
+            >
+              <option value="newest">Newest to Oldest</option>
+              <option value="oldest">Oldest to Newest</option>
+              <option value="popular">Most Popular</option>
+            </Select>
+          </Flex>
+        </Box>
         <Container maxW="container.xl" py={8}>
           <Stack align="center" spacing={4}>
-            <Heading mt={8} mb={8}>
-              Blog Posts
-            </Heading>
+            <Heading mt={8} mb={8}>Blog Posts</Heading>
             <Divider />
             {post.isLoading ? (
               <Fade
@@ -72,7 +158,7 @@ export default function BlogDashboard() {
                 gap={6}
                 w="100%"
               >
-                {post.posts.map((p, index) => (
+                {filteredPosts.map((p, index) => (
                   <GridItem key={p.slug}>
                     <Fade
                       in


### PR DESCRIPTION
- Replaced the single-category dropdown with a themed popover component, enabling multi-category selection and quick clearing of chosen categories
- Added a popularity sort option based on view counts and styled the sort menu using palette colors
- Updated the sticky control bar with theme-based backgrounds and displayed the count of posts matching current filters