### PR TITLE
fix(blog): responsive markdown & code-block rendering on mobile

### DIFF
--- a/src/components/Post/index.js
+++ b/src/components/Post/index.js
@@ -56,7 +56,7 @@ export default function Post({ post }) {
         boxShadow="xl"
         borderRadius="xl"
       >
-        <Stack m={5} spacing={4}>
+        <Stack m={5} spacing={4} minW={0}>
           {isCourseReview(post) && (
             <>
               <CourseReviewStats post={post} />

--- a/src/components/TextBox/CodeBlock.jsx
+++ b/src/components/TextBox/CodeBlock.jsx
@@ -1,0 +1,43 @@
+import { Box, Code } from "@chakra-ui/react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { coldarkDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+export default function CodeBlock({ children, className, node, ...rest }) {
+  const match = /language-(\w+)/.exec(className || "");
+
+  if (!match) {
+    return (
+      <Code
+        {...rest}
+        className={className}
+        rounded="md"
+        whiteSpace="pre-wrap"
+        wordBreak="break-word"
+      >
+        {children}
+      </Code>
+    );
+  }
+
+  const language = match[1];
+
+  return (
+    <Box maxW="100%" minW={0} borderRadius="md" overflow="hidden">
+      <Box bg="gray.300" color="white" p={1}>
+        <Code fontSize="sm" aria-hidden="true">
+          {language}
+        </Code>
+      </Box>
+      <Box maxW="100%" overflowX="auto">
+        <SyntaxHighlighter
+          {...rest}
+          PreTag="div"
+          children={String(children).replace(/\n$/, "")}
+          language={language}
+          style={coldarkDark}
+          customStyle={{ margin: 0, borderRadius: 0 }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/TextBox/index.js
+++ b/src/components/TextBox/index.js
@@ -1,36 +1,13 @@
+import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
 
 import "katex/dist/katex.min.css";
 import ChakraUIRenderer from "chakra-ui-markdown-renderer";
-import { Box, Code } from "@chakra-ui/react";
-import { coldarkDark } from "react-syntax-highlighter/dist/esm/styles/prism";
-
-const codeComponent =
-  (style) =>
-  ({ children, className, node, ...rest }) => {
-    const match = /language-(\w+)/.exec(className || "");
-    return match ? (
-      <>
-        <Box bg="gray.300" color="white" p={1} roundedTop="md">
-          <Code fontSize="sm">{match[1]}</Code>
-        </Box>
-        <SyntaxHighlighter
-          {...rest}
-          PreTag="div"
-          className="rounded-md"
-          children={String(children).replace(/\n$/, "")}
-          language={match[1]}
-          style={style}
-        />
-      </>
-    ) : (
-      <Code {...rest} className={className} rounded="md" children={children} />
-    );
-  };
+import { Box, Image, Table, TableContainer } from "@chakra-ui/react";
+import CodeBlock from "./CodeBlock";
 
 const blockQuoteComponent = ({ children }) => (
   <blockquote className="border-l-4 rounded-sm border-blue-200 bg-gray-30 p-4 my-4 mx-2 italic text-gray-600">
@@ -45,26 +22,64 @@ const blockQuoteComponent = ({ children }) => (
  * @returns
  */
 export default function TextBox({ text, color = "inherit" }) {
-  return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex]}
-      components={ChakraUIRenderer({
-        p: (props) => (
-          <p style={{ color: color, marginBottom: '1rem' }} {...props}>
-            {props.children}
+  const markdownComponents = useMemo(
+    () =>
+      ChakraUIRenderer({
+        p: ({ children, node, ...props }) => (
+          <p
+            style={{
+              color: color,
+              marginBottom: "1rem",
+              overflowWrap: "anywhere",
+            }}
+            {...props}
+          >
+            {children}
           </p>
         ),
-        span: (props) => (
+        span: ({ children, node, ...props }) => (
           <span style={{ color: color }} {...props}>
-            {props.children}
+            {children}
           </span>
         ),
-        a: (props) => <a style={{ color: "blue" }} {...props} />,
-        code: codeComponent(coldarkDark),
+        a: ({ children, href, node, ...props }) => {
+          const isExternal = /^https?:\/\//i.test(href || "");
+
+          return (
+            <a
+              style={{ color: "blue" }}
+              href={href}
+              target={isExternal ? "_blank" : undefined}
+              rel={isExternal ? "noopener noreferrer" : undefined}
+              {...props}
+            >
+              {children}
+            </a>
+          );
+        },
+        code: CodeBlock,
+        pre: ({ node, ...props }) => (
+          <Box as="div" maxW="100%" minW={0} mb={4} {...props} />
+        ),
+        table: ({ children, node, ...props }) => (
+          <TableContainer maxW="100%" overflowX="auto" mb={4}>
+            <Table {...props}>{children}</Table>
+          </TableContainer>
+        ),
+        img: ({ node, ...props }) => <Image maxW="100%" h="auto" {...props} />,
         blockquote: blockQuoteComponent,
-      })}
-      children={text}
-    />
+      }),
+    [color]
+  );
+
+  return (
+    <Box minW={0} maxW="100%">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={markdownComponents}
+        children={text}
+      />
+    </Box>
   );
 }

--- a/src/components/TextInputMD/index.js
+++ b/src/components/TextInputMD/index.js
@@ -7,7 +7,7 @@ export default function TextInputMD({ text, handleChange, ...rest }) {
     <Stack w="100%" h="90%" spacing={2} mx="auto" px={2}>
       <Divider />
       <Grid
-        templateColumns="1fr 1fr" // Split into two equal columns
+        templateColumns={{ base: "1fr", md: "1fr 1fr" }} // Stack on mobile, split into two equal columns on larger screens
         gap={2}
         w="100%"
         h="100%" // Set height to fill the parent

--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,9 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.katex-display {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+}


### PR DESCRIPTION
Markdown/code blocks overflowed the viewport and forced whole-page horizontal scroll on small screens. Root cause: fenced code sat inside chakra-ui-markdown-renderer's <Code whiteSpace=pre> wrapper and flex ancestors defaulted to min-width:auto, so a wide block widened the page instead of scrolling in its own box.

- Extract code rendering into TextBox/CodeBlock.jsx (single purpose): block code scrolls inside a bounded rounded box; inline code wraps.
- TextBox: root minW=0/maxW=100% boundary; override pre/table/img; external links get target=_blank rel=noopener; memoize renderer map.
- Post: minW=0 on content Stack so it can shrink in flex ancestors.
- TextInputMD: editor grid stacks on mobile (base 1fr / md 1fr 1fr).
- index.css: .katex-display scrolls horizontally (block math).

Reviewed by gemini-3.1-pro; implemented by gpt-5.5. Stack unchanged (react-markdown@8 + react-syntax-highlighter); bundle-size swap deferred.